### PR TITLE
refactored search. When creating artist, the view does NOT reset to s…

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -29,9 +29,9 @@ function initiateEventListeners() {
     const searchbar = document.querySelector("#searchbar");
     searchbar?.addEventListener("input", () => {
         const searchValue = searchbar.value.toLowerCase();
-        artistRenders.search(searchValue);
-        albumRenders.search(searchValue);
-        trackRenders.search(searchValue);
+        artistRenders.setSearchValue(searchValue);
+        albumRenders.setSearchValue(searchValue);
+        trackRenders.setSearchValue(searchValue);
     });
 }
 export { artistRenders, albumRenders, trackRenders };

--- a/dist/view/ListRenderer.js
+++ b/dist/view/ListRenderer.js
@@ -21,10 +21,11 @@ export default class ListRenderer {
     clearList() {
         this.container.innerHTML = "";
     }
-    renderList(filteredList) {
+    renderList() {
         this.clearList();
-        this.sort(filteredList ?? this.list);
-        for (const item of filteredList ?? this.list) {
+        const list = this.search();
+        this.sort(list);
+        for (const item of list) {
             const html = item.renderHTML();
             this.container.insertAdjacentHTML("beforeend", html);
             if (this.container.lastElementChild) {
@@ -33,19 +34,20 @@ export default class ListRenderer {
         }
     }
     setList(newList) {
-        console.log(newList);
         this.list = [];
         for (const item of newList) {
             this.list.push(new this.itemRenderer(item));
         }
     }
-    search(searchValue) {
-        if (searchValue || searchValue == "") {
-            this.searchValue = searchValue;
+    setSearchValue(newSearchValue) {
+        if (newSearchValue || newSearchValue == "") {
+            this.searchValue = newSearchValue;
         }
+        this.renderList();
+    }
+    search() {
         if (!this.searchValue) {
-            this.renderList();
-            return;
+            return this.list;
         }
         const filteredList = this.list.filter((item) => {
             if (item instanceof ArtistRenderer) {
@@ -55,7 +57,7 @@ export default class ListRenderer {
                 return item.item.title.toLowerCase().includes(this.searchValue);
             }
         });
-        this.renderList(filteredList);
+        return filteredList;
     }
     sort(list) {
         list.sort((b, a) => {
@@ -73,11 +75,11 @@ export default class ListRenderer {
     postRender() {
         this.sortContainer.querySelector(".sort")?.addEventListener("change", () => {
             this.sortValue = this.sortContainer.querySelector(".sort")?.value;
-            this.search();
+            this.setSearchValue();
         });
         this.sortContainer.querySelector(".sort-order")?.addEventListener("change", () => {
             this.sortByValue = this.sortContainer.querySelector(".sort-order")?.value;
-            this.search();
+            this.setSearchValue();
         });
     }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -40,14 +40,10 @@ function initiateEventListeners() {
     const searchbar = document.querySelector("#searchbar") as HTMLInputElement;
     searchbar?.addEventListener("input", () => {
         const searchValue = searchbar.value.toLowerCase();
-        
-        
-        artistRenders.search(searchValue);
-        albumRenders.search(searchValue);
-        trackRenders.search(searchValue);
 
-        
-
+        artistRenders.setSearchValue(searchValue);
+        albumRenders.setSearchValue(searchValue);
+        trackRenders.setSearchValue(searchValue);
     });
 }
 

--- a/src/view/ListRenderer.ts
+++ b/src/view/ListRenderer.ts
@@ -30,18 +30,17 @@ export default class ListRenderer {
         this.postRender();
     }
 
-
     public clearList(): void {
         this.container.innerHTML = "";
     }
 
-
-    public renderList(filteredList?: (AlbumRenderer | TrackRenderer | ArtistRenderer)[]): void {
+    public renderList(): void {
         this.clearList();
 
-        this.sort(filteredList ?? this.list);
+        const list = this.search();
+        this.sort(list);
 
-        for (const item of filteredList ?? this.list) {
+        for (const item of list) {
             const html = item.renderHTML();
             this.container.insertAdjacentHTML("beforeend", html);
 
@@ -52,22 +51,23 @@ export default class ListRenderer {
     }
 
     public setList(newList: any[]) {
-        console.log(newList);
         this.list = [];
         for (const item of newList) {
             this.list.push(new this.itemRenderer(item));
         }
     }
 
-    public search(searchValue?: string) {
-
-        if (searchValue || searchValue == "") {
-            this.searchValue = searchValue;
+    public setSearchValue(newSearchValue?: string) {
+        if (newSearchValue || newSearchValue == "") {
+            this.searchValue = newSearchValue;
         }
-        
+
+        this.renderList();
+    }
+
+    private search() {
         if (!this.searchValue) {
-            this.renderList();
-            return;
+            return this.list;
         }
 
         const filteredList = this.list.filter((item) => {
@@ -78,7 +78,7 @@ export default class ListRenderer {
             }
         });
 
-        this.renderList(filteredList);
+        return filteredList;
     }
 
     private sort(list: (AlbumRenderer | TrackRenderer | ArtistRenderer)[]): void {
@@ -98,13 +98,12 @@ export default class ListRenderer {
     private postRender() {
         this.sortContainer.querySelector(".sort")?.addEventListener("change", () => {
             this.sortValue = (this.sortContainer.querySelector(".sort") as HTMLSelectElement)?.value;
-            this.search();
+            this.setSearchValue();
         });
 
         this.sortContainer.querySelector(".sort-order")?.addEventListener("change", () => {
             this.sortByValue = (this.sortContainer.querySelector(".sort-order") as HTMLSelectElement)?.value;
-            this.search();
+            this.setSearchValue();
         });
     }
-
 }


### PR DESCRIPTION
…how all artists. Instead, it will take the search value into account and keep the filtered view displayed after creating a new artist

LÆS NEDENSTÅENDE::::
I main-branch resetter vores display af artister til at vise samtlige, efter der oprettes et nyt artist-objekt. Dette gør den, SELVOM searchbaren har inputs, og der burde filtreres derefter.

Dette har jeg fixed i denne branch. I må gerne reviewe.